### PR TITLE
feat(stroppy): add getting of monitoring data for several clusters on one user machine

### DIFF
--- a/docs/examples/deploy-oracle-3node-2cpu-8gbRAM-100gbStorage/monitoring/grafana-on-premise/get_png.sh
+++ b/docs/examples/deploy-oracle-3node-2cpu-8gbRAM-100gbStorage/monitoring/grafana-on-premise/get_png.sh
@@ -1,15 +1,23 @@
 #!/bin/bash
-# Usage: 
-# ./get_png.sh 1622733157321 1622744447611
-# where $1 start in nuix time, $2 end in nuix time
-# vars
+# Example usage: 
+# ./get_png.sh 1637859362000 1637895618000 3000 mongo_100mln_pay_6cpu_16GB_without_operator_with_arb.tar.gz "10.1.20.171;10.1.20.73;10.1.20.210;10.1.20.90;10.1.20.138"
+# where 
+#$1 -  start in unix time, 
+#$2 - end in unix time
+#$3 - port of grafana
+#$4 - name of archive with dashboard images
+#$5 - string with internal cluster machines ip addresses
+#
+#
+#
 rm -rf png
 
 start=$1
 end=$2
-arch_name=$3
-ip_string=$4
-base_url="http://admin:admin@localhost:3000/render/d-solo"
+port=$3
+arch_name=$4
+ip_string=$5
+base_url="http://admin:admin@localhost:$port/render/d-solo"
 tz="tz=Europe%2FMoscow"
 
 ip_array=($(echo $ip_string | tr ";" "\n"))

--- a/docs/examples/deploy-oracle-5node-1cpu-8gbRAM-100gbStorage/monitoring/grafana-on-premise/get_png.sh
+++ b/docs/examples/deploy-oracle-5node-1cpu-8gbRAM-100gbStorage/monitoring/grafana-on-premise/get_png.sh
@@ -1,15 +1,23 @@
 #!/bin/bash
-# Usage: 
-# ./get_png.sh 1622733157321 1622744447611
-# where $1 start in nuix time, $2 end in nuix time
-# vars
+# Example usage: 
+# ./get_png.sh 1637859362000 1637895618000 3000 mongo_100mln_pay_6cpu_16GB_without_operator_with_arb.tar.gz "10.1.20.171;10.1.20.73;10.1.20.210;10.1.20.90;10.1.20.138"
+# where 
+#$1 -  start in unix time, 
+#$2 - end in unix time
+#$3 - port of grafana
+#$4 - name of archive with dashboard images
+#$5 - string with internal cluster machines ip addresses
+#
+#
+#
 rm -rf png
 
 start=$1
 end=$2
-arch_name=$3
-ip_string=$4
-base_url="http://admin:admin@localhost:3000/render/d-solo"
+port=$3
+arch_name=$4
+ip_string=$5
+base_url="http://admin:admin@localhost:$port/render/d-solo"
 tz="tz=Europe%2FMoscow"
 
 ip_array=($(echo $ip_string | tr ";" "\n"))

--- a/docs/examples/deploy-yandex-3node-2cpu-8gbRAM-100gbStorage/monitoring/grafana-on-premise/get_png.sh
+++ b/docs/examples/deploy-yandex-3node-2cpu-8gbRAM-100gbStorage/monitoring/grafana-on-premise/get_png.sh
@@ -1,22 +1,30 @@
 #!/bin/bash
-# Usage: 
-# ./get_png.sh 1622733157321 1622744447611
-# where $1 start in nuix time, $2 end in nuix time
-# vars
+# Example usage: 
+# ./get_png.sh 1637859362000 1637895618000 3000 mongo_100mln_pay_6cpu_16GB_without_operator_with_arb.tar.gz "10.1.20.171;10.1.20.73;10.1.20.210;10.1.20.90;10.1.20.138"
+# where 
+#$1 -  start in unix time, 
+#$2 - end in unix time
+#$3 - port of grafana
+#$4 - name of archive with dashboard images
+#$5 - string with internal cluster machines ip addresses
+#
+#
+#
 rm -rf png
 
 start=$1
 end=$2
-arch_name=$3
-ip_string=$4
-base_url="http://admin:admin@localhost:3000/render/d-solo"
+port=$3
+arch_name=$4
+ip_string=$5
+base_url="http://admin:admin@localhost:$port/render/d-solo"
 tz="tz=Europe%2FMoscow"
 
 ip_array=($(echo $ip_string | tr ";" "\n"))
 
 for theme in "light" "dark"
 do
-    for size in  "width=1000&height=500" 
+    for size in "width=3000&height=1800" "width=1000&height=500"
     do
         mkdir -p "png/$size/$theme/node-exporter"
         mkdir -p "png/$size/$theme/k8s"
@@ -65,5 +73,6 @@ do
 done
 
 mv 'png/width=1000&height=500'  png/1000x500
+mv 'png/width=3000&height=1800' png/3000x1800
 
 tar cfvz $arch_name png

--- a/docs/examples/deploy-yandex-5node-1cpu-8gbRAM-100gbStorage/monitoring/grafana-on-premise/get_png.sh
+++ b/docs/examples/deploy-yandex-5node-1cpu-8gbRAM-100gbStorage/monitoring/grafana-on-premise/get_png.sh
@@ -1,22 +1,30 @@
 #!/bin/bash
-# Usage: 
-# ./get_png.sh 1622733157321 1622744447611
-# where $1 start in nuix time, $2 end in nuix time
-# vars
+# Example usage: 
+# ./get_png.sh 1637859362000 1637895618000 3000 mongo_100mln_pay_6cpu_16GB_without_operator_with_arb.tar.gz "10.1.20.171;10.1.20.73;10.1.20.210;10.1.20.90;10.1.20.138"
+# where 
+#$1 -  start in unix time, 
+#$2 - end in unix time
+#$3 - port of grafana
+#$4 - name of archive with dashboard images
+#$5 - string with internal cluster machines ip addresses
+#
+#
+#
 rm -rf png
 
 start=$1
 end=$2
-arch_name=$3
-ip_string=$4
-base_url="http://admin:admin@localhost:3000/render/d-solo"
+port=$3
+arch_name=$4
+ip_string=$5
+base_url="http://admin:admin@localhost:$port/render/d-solo"
 tz="tz=Europe%2FMoscow"
 
 ip_array=($(echo $ip_string | tr ";" "\n"))
 
 for theme in "light" "dark"
 do
-    for size in  "width=1000&height=500" 
+    for size in "width=3000&height=1800" "width=1000&height=500"
     do
         mkdir -p "png/$size/$theme/node-exporter"
         mkdir -p "png/$size/$theme/k8s"
@@ -65,5 +73,6 @@ do
 done
 
 mv 'png/width=1000&height=500'  png/1000x500
+mv 'png/width=3000&height=1800' png/3000x1800
 
 tar cfvz $arch_name png

--- a/internal/deployment/constants.go
+++ b/internal/deployment/constants.go
@@ -12,10 +12,8 @@ Started ssh tunnel for kubernetes cluster and port-forward for monitoring.
 To access Grafana use address localhost:%d.
 To access to kubernetes cluster in cloud use address localhost:%d.
 Enter "quit" or "exit" to exit stroppy and destroy cluster.
-Enter "pop" to start populating PostgreSQL with accounts.
-Enter "pay" to start transfers test in PostgreSQL.
-Enter "pop" to start populating FoundationDB with accounts.
-Enter "pay" to start transfers test in FoundationDB.
+Enter "pop" to start populating deployed DB with accounts.
+Enter "pay" to start transfers test in deployed DB.
 To use kubectl for access kubernetes cluster in another console 
 execute command for set environment variables KUBECONFIG before using:
 "export KUBECONFIG=$(pwd)/config"`

--- a/internal/deployment/deploy.go
+++ b/internal/deployment/deploy.go
@@ -180,7 +180,6 @@ func (sh *shell) deploy() (err error) {
 
 	llog.Infof("'%s' database cluster deployed successfully", sh.settings.DatabaseSettings.DBType)
 
-	grafanaPort, kubernetesMasterPort := sh.k.GetInfraPorts()
-	llog.Infof(interactiveUsageHelpTemplate, grafanaPort, kubernetesMasterPort)
+	llog.Infof(interactiveUsageHelpTemplate, sh.k.MonitoringPort.Port, sh.k.KubernetesPort.Port)
 	return
 }

--- a/internal/deployment/shell.go
+++ b/internal/deployment/shell.go
@@ -129,7 +129,7 @@ func (sh *shell) RunRemotePayTest() (err error) {
 
 	// таймаут, чтобы не получать пустое место на графиках
 	time.Sleep(20 * time.Second)
-	if err = sh.k.Engine.StartCollectMonitoringData(beginTime, endTime, monImagesArchName); err != nil {
+	if err = sh.k.Engine.CollectMonitoringData(beginTime, endTime, sh.k.MonitoringPort.Port, monImagesArchName); err != nil {
 		err = merry.Prepend(err, "failed to get monitoring images for pop test")
 	}
 
@@ -153,7 +153,7 @@ func (sh *shell) RunRemotePopTest() (err error) {
 
 	// таймаут, чтобы не получать пустое место на графиках
 	time.Sleep(20 * time.Second)
-	if err = sh.k.Engine.StartCollectMonitoringData(beginTime, endTime, monImagesArchName); err != nil {
+	if err = sh.k.Engine.CollectMonitoringData(beginTime, endTime, sh.k.MonitoringPort.Port, monImagesArchName); err != nil {
 		err = merry.Prepend(err, "failed to get monitoring images for pop test")
 	}
 

--- a/internal/deployment/tools.go
+++ b/internal/deployment/tools.go
@@ -72,7 +72,7 @@ func (sh *shell) executePay(_ string) (err error) {
 
 	// таймаут, чтобы не получать пустое место на графиках
 	time.Sleep(20 * time.Second)
-	if err = sh.k.Engine.StartCollectMonitoringData(beginTime, endTime, monImagesArchName); err != nil {
+	if err = sh.k.Engine.CollectMonitoringData(beginTime, endTime, sh.k.MonitoringPort.Port, monImagesArchName); err != nil {
 		return merry.Prepend(err, "failed to get monitoring images for pay test")
 	}
 
@@ -134,7 +134,7 @@ func (sh *shell) executePop(_ string) (err error) {
 
 	// таймаут, чтобы не получать пустое место на графиках
 	time.Sleep(20 * time.Second)
-	if err = sh.k.Engine.StartCollectMonitoringData(beginTime, endTime, monImagesArchName); err != nil {
+	if err = sh.k.Engine.CollectMonitoringData(beginTime, endTime, sh.k.MonitoringPort.Port, monImagesArchName); err != nil {
 		return merry.Prepend(err, "failed to get monitoring images for pop test")
 	}
 
@@ -162,7 +162,7 @@ func (sh *shell) readDatabaseConfig(cmdType string) (settings *config.DatabaseSe
 	case cluster.Foundation:
 		settings.DBURL = "fdb.cluster"
 	case cluster.MongoDB:
-		settings.DBURL = "mongodb://stroppy:stroppy@my-cluster-name-mongos.default.svc.cluster.local/admin?ssl=false"
+		settings.DBURL = "mongodb://stroppy:stroppy@sample-cluster-name-mongos.default.svc.cluster.local/admin?ssl=false"
 	default:
 		err = merry.Errorf("unknown db type '%s'", sh.settings.DatabaseSettings.DBType)
 		return

--- a/pkg/engine/kubeengine/toolfuncs.go
+++ b/pkg/engine/kubeengine/toolfuncs.go
@@ -147,7 +147,7 @@ func (e *Engine) parseKubernetesFilePath(path string) (podName, containerName, i
 
 // ExecuteGetingMonImages собирает данные мониторинга.
 // Осуществляется запуском скрипта get_png.sh, результат работы которого - архив с набором png-файлов
-func (e Engine) StartCollectMonitoringData(startTime int64, finishTime int64, monImagesArchName string) error {
+func (e Engine) CollectMonitoringData(startTime int64, finishTime int64, monitoringPort int, monImagesArchName string) error {
 	llog.Infoln("Starting to get monitoring images...")
 
 	llog.Debugln("start time of monitoring data range", time.Unix(startTime/1000, 0).UTC())
@@ -160,7 +160,7 @@ func (e Engine) StartCollectMonitoringData(startTime int64, finishTime int64, mo
 	}
 
 	workingDirectory := filepath.Join(e.WorkingDirectory, "monitoring", "grafana-on-premise")
-	getImagesCmd := exec.Command("./get_png.sh", fmt.Sprintf("%v", startTime), fmt.Sprintf("%v", finishTime), monImagesArchName, workersIps)
+	getImagesCmd := exec.Command("./get_png.sh", fmt.Sprintf("%v", startTime), fmt.Sprintf("%v", finishTime), fmt.Sprintf("%v", monitoringPort), monImagesArchName, workersIps)
 	getImagesCmd.Dir = workingDirectory
 	if result, err := getImagesCmd.CombinedOutput(); err != nil {
 		llog.Errorln(string(result))

--- a/pkg/kubernetes/definitions.go
+++ b/pkg/kubernetes/definitions.go
@@ -31,6 +31,6 @@ type Kubernetes struct {
 
 	StroppyPod *stroppy.Pod
 
-	sshTunnel   *ssh.Result
-	portForward *ssh.Result
+	KubernetesPort *ssh.Result
+	MonitoringPort *ssh.Result
 }


### PR DESCRIPTION
Added new parameter "port" in getting data function CollectMonitoringData() for getting data from other clusters.
Parameters of ports for monitoring and kubernetes renamed and had become exportable for using in CollectMonitoringData().
Method GetInfraports() deleted, because it is not needed anymore.