### PR TITLE
fix(stroppy-cartridge): add storage role in replicasets.yaml

### DIFF
--- a/third_party/stroppy-test-cartridge/replicasets.yml
+++ b/third_party/stroppy-test-cartridge/replicasets.yml
@@ -4,13 +4,13 @@ router:
   roles:
   - failover-coordinator
   - vshard-router
-  - app.roles.custom
+  - app.roles.api
   all_rw: false
 s-1:
   instances:
   - s1-master
-  - s1-replica
   roles:
+  - app.roles.api
   - vshard-storage
   weight: 1
   all_rw: false
@@ -18,8 +18,8 @@ s-1:
 s-2:
   instances:
   - s2-master
-  - s2-replica
   roles:
+  - app.roles.api
   - vshard-storage
   weight: 1
   all_rw: false


### PR DESCRIPTION
fix error "graphql: replicasets[aac9ea43-04b9-567d-a63a-ff01e2e14533] can not enable unknown role \"app.roles.storage\"" in tarantool-operator