### PR TITLE
Updated YDB support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.vscode
 .vagrant
 *.log
 

--- a/cmd/stroppy/commands/pop.go
+++ b/cmd/stroppy/commands/pop.go
@@ -22,7 +22,7 @@ func newPopCommand(settings *config.Settings) *cobra.Command {
 		Use:     "pop",
 		Aliases: []string{"populate"},
 		Short:   "Create and populate the accounts database",
-		Example: "./stroppy pop -c 100000000",
+		Example: "./stroppy pop -n 100000000",
 
 		PersistentPreRunE: func(_ *cobra.Command, _ []string) error {
 			return initLogFacility(settings)

--- a/pkg/engine/db/yandex.go
+++ b/pkg/engine/db/yandex.go
@@ -622,6 +622,7 @@ func (yc *yandexCluster) Connect() (interface{}, error) {
 	if connection, err = cluster.NewYandexDBCluster(
 		ydbContext,
 		yc.commonCluster.DBUrl,
+		yc.commonCluster.connectionPoolSize,
 	); err != nil {
 		return nil, merry.Prepend(err, "Error then creating new YDB cluster")
 	}


### PR DESCRIPTION
YDB related fixes, version 2:
1. Text caching for repeatable statements - lower CPU on stroppy side
2. YC managed YDB support
3. Proper session pool size configuration, removed manual session management
4. Using short table paths (`stroppy/account`) where possible
5. Example implementation of FetchAccounts() and FetchBalance()
6. Proper transaction logic in MakeAtomicTransfer() - WAS WRONG IN THE PREVIOUS VERSION!